### PR TITLE
Fixed call private self method copy_defaults in settings_manager.rb

### DIFF
--- a/lib/taverna_player_portal/settings_manager.rb
+++ b/lib/taverna_player_portal/settings_manager.rb
@@ -10,7 +10,7 @@ module TavernaPlayerPortal
     DEFAULT_SETTINGS_PATH = Rails.root.join('config', 'settings.yml.example')
 
     def load
-      self.copy_defaults unless File.exist?(SETTINGS_PATH)
+      self.class.copy_defaults unless File.exist?(SETTINGS_PATH)
 
       @hash = YAML.load_file(SETTINGS_PATH)
       TavernaPlayerPortal.settings = OpenStruct.new(@hash)
@@ -22,7 +22,7 @@ module TavernaPlayerPortal
     end
 
     def reset
-      self.copy_defaults
+      self.class.copy_defaults
       load
     end
 


### PR DESCRIPTION
I've got error when start rails server without file config/settings.yml.
I fixed this error