### PR TITLE
Runs for specific user API call

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,15 @@ class ApplicationController < ActionController::Base
 
   before_filter :configure_permitted_devise_params, if: :devise_controller?
 
+  def runs
+    @runs = TavernaPlayer::Run.where(:user => params[:user_id]).order('created_at DESC').with_permissions(current_user, :view).page(params[:page])
+    respond_to do |format|
+      format.json { render json: @runs}
+      format.xml { render xml: @runs}
+    end
+
+  end
+
   protected
 
   def check_logged_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   before_filter :configure_permitted_devise_params, if: :devise_controller?
 
   def runs
-    @runs = TavernaPlayer::Run.where(:user => params[:user_id]).order('created_at DESC').with_permissions(current_user, :view).page(params[:page])
+    @runs = TavernaPlayer::Run.where(:user => params[:user_id]).order('created_at DESC').with_permissions(current_user, :edit).page(params[:page])
     respond_to do |format|
       format.json { render json: @runs}
       format.xml { render xml: @runs}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,4 +24,8 @@ TavernaPlayerPortal::Application.routes.draw do
   # This application adds the ability to edit runs so specify that here.
   resources :runs, controller: 'taverna_player/runs', only: ['edit', 'update']
 
+  resources :users, controller: 'application', :defaults => { :format => :json } do
+    get 'runs'
+  end
+
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionController::TestCase
+
+  test "get runs for user" do
+    @routes = TavernaPlayerPortal::Application.routes
+    run = create(:run)
+    sign_in run.user
+    get :runs, user_id: run.user.id, :format => "json"
+
+    assert_not_nil assigns(:runs)
+    assert_not_empty assigns(:runs)
+    assert_response :success
+  end
+
+  test "should be no runs if not signed in" do
+    @routes = TavernaPlayerPortal::Application.routes
+    run = create(:run)
+    #sign_in run.user
+    get :runs, user_id: run.user.id, :format => "json"
+
+    assert_not_nil assigns(:runs)
+    assert_empty assigns(:runs)
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
Added json/xml api to view all runs for a particular user via /users/:user_id/runs. Put it in the app controller because I couldn't think of anywhere better. Only those with edit permission on the runs for that user will get anything in the response.
